### PR TITLE
Added reference to Artifactory reference architecture

### DIFF
--- a/playbooks/installation/index.adoc
+++ b/playbooks/installation/index.adoc
@@ -316,6 +316,8 @@ In addition to RPM content, OpenShift requires the ability to pull container ima
 
 One of the primary functions of OpenShift is to build applications and to produce new images. As part of the image building process, access to resources to satisfy the build process must be in available and include the source code (from a git repository) along with any dependencies the build process may need.
 
+NOTE: Integration with JFrog Artifactory as a deployed application to manage application artifacts and Docker images is covered in this link:https://access.redhat.com/documentation/en-us/reference_architectures/2017/html-single/jfrog_artifactory_on_openshift_container_platform/[reference architecture].
+
 OpenShift includes a number of application link:https://docs.openshift.com/container-platform/latest/dev_guide/templates.html[templates] to allow developer to quickly take advantage of the build and deployment features provided by the platform. The examples make use of repositories located on GitHub. As mentioned previously, access to these repositories must be available in order for their usability. In some cases where OpenShift is fully running in a disconnected environment, it may be necessary to synchronize the contents from GitHub to a repository accessible by the OpenShift cluster. Additional steps would need to be taken to either modify the default templates provided by OpenShift or include proper documentation for developer who are looking to leverage the default templates.
 
 This topic is not covered in this guide.


### PR DESCRIPTION
#### What is this PR About?
Includes link to [OpenShift Artifactory reference architecture](https://access.redhat.com/documentation/en-us/reference_architectures/2017/html-single/jfrog_artifactory_on_openshift_container_platform/) in install guide

#### How should we test or review this PR?
Review change

#### Is there a relevant Trello card or Github issue open for this?
https://trello.com/c/IHenQ7Tt
https://github.com/redhat-cop/openshift-playbooks/issues/146

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this
