### PR TITLE
Updated installation/index.adoc to correct the order and syntax of…

### DIFF
--- a/playbooks/installation/index.adoc
+++ b/playbooks/installation/index.adoc
@@ -451,7 +451,7 @@ openshift-appnode-2.c1-ocp.myorg.com
 Test ansible in an adhoc way to ensure it can get to all the nodes
 
 ----
-ansible -i /some/path/to/my/hosts/inventory/file OSEv3 -m ping
+ansible -i c1-ocp.myorg.com/hosts OSEv3 -m ping
 ----
 
 

--- a/playbooks/installation/index.adoc
+++ b/playbooks/installation/index.adoc
@@ -425,12 +425,6 @@ ssh-copy-id -i ~/.ssh/Myidrsa.pub remote.server.com
 
 ssh will require you to accept the new ssh key for the first time into the `~/.ssh/known_hosts` file by either shelling into each of the nodes one by one and typing yes each time or adding the file `~/.ssh/config` file with perms of 600 with a line that includes `StrictHostKeyChecking no`.  Once this is completed you can test that ansible will no longer ask to accept the key
 
-Test ansible in an adhoc way to ensure it can get to all the nodes
-
-----
-ansible -i /some/path/to/my/hosts/inventory/file -hosts OSEv3 -m ping
-----
-
 ==== Cloud-Specific Provisioning Guides
 
 * Provisioning infrastructure on OpenStack using the openstack CLI (Coming Soon)
@@ -453,6 +447,13 @@ openshift-infranode-[1:3].c1-ocp.myorg.com
 openshift-appnode-1.c1-ocp.myorg.com.com
 openshift-appnode-2.c1-ocp.myorg.com
 ----
+
+Test ansible in an adhoc way to ensure it can get to all the nodes
+
+----
+ansible -i /some/path/to/my/hosts/inventory/file OSEv3 -m ping
+----
+
 
 === Create Standalone Registry
 


### PR DESCRIPTION
…the ansible command to validate connectivity from the control host to all of our node servers

#### What is this PR About?
Resolved ordering of the ansible test command we run to validate connectivity from the control host to all of our node servers in the Provision Server section of the installation guid (now happens after the section where we add the hosts to the host groups in our inventory file)

Also, removed the -hosts parameter in the ansible command (should work simply by providing the hosts group)

#### How should we test or review this PR?
Confirm that the ansible test command is correctly ordered and validate that the ansible test command syntax is correct

#### Is there a relevant Trello card or Github issue open for this?
#151 

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this
