### PR TITLE
Removed note regarding src path

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,8 +23,6 @@ docker-compose up -d
 ----
 3. Launch browser and navigate to `http://localhost:4000`
 
-NOTE: This process assumes you've checked out the code to ~/src/openshift-playbooks. If you are cloning to a different location, you'll need to update `docker-compose.yml`
-
 === Quickstart Guide using RHEL (or derivatives)
 
 1. Install necessary packages.


### PR DESCRIPTION
#### What is this PR About?
Removed the callout on the index page to modify the location of the source code path in the `docker-compose.yml` file. By default, the location references the current directory

#### How should we test or review this PR?
Review changes

#### Is there a relevant Trello card or Github issue open for this?
No

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this
