### PR TITLE
Update base64 usage doc in secure-forward-splunk.adoc

### DIFF
--- a/playbooks/operationalizing/secure-forward-splunk.adoc
+++ b/playbooks/operationalizing/secure-forward-splunk.adoc
@@ -194,8 +194,8 @@ A secret called _logging-fluentd_ are already configured within the logging infr
 
 [source]
 ----
-oc patch secrets/logging-fluentd --type=json --patch "[{'op':'add','path':'/data/external_ca_cert.pem','value':'$(base64 /path/to/your_ca_cert.pem)'}]"
-oc patch secrets/logging-fluentd --type=json --patch "[{'op':'add','path':'/data/external_ca_key.pem','value':'$(base64 /path/to/your_private_key.pem)'}]"
+oc patch secrets/logging-fluentd --type=json --patch "[{'op':'add','path':'/data/external_ca_cert.pem','value':'$(base64 -w 0 /path/to/your_ca_cert.pem)'}]"
+oc patch secrets/logging-fluentd --type=json --patch "[{'op':'add','path':'/data/external_ca_key.pem','value':'$(base64 -w 0 /path/to/your_private_key.pem)'}]"
 ----
 
 [NOTE]


### PR DESCRIPTION
base64 should be given the -w 0 (non-wrap) option to ensure the encoded certificate does not contain a newline character.