### PR TITLE
Add <store> tags to secure forward configmap

### DIFF
--- a/playbooks/operationalizing/secure-forward-splunk.adoc
+++ b/playbooks/operationalizing/secure-forward-splunk.adoc
@@ -215,6 +215,7 @@ Edit the secure-forward.conf file contained within the ConfigMap using the comma
 [source]
 ----
   secure-forward.conf: |
+    <store>
     @type secure_forward
 
     self_hostname "#{ENV['HOSTNAME']}"
@@ -231,6 +232,7 @@ Edit the secure-forward.conf file contained within the ConfigMap using the comma
       host 10.9.49.72 <5>
       port 24284 <6>
     </server>
+    </store>
 ----
 <1> Value shared between both ends of the secure forward plugin
 <2> Location of the certificate used by the secure forward plugin


### PR DESCRIPTION
#### What is this PR About?
Updates the configuration based on the latest documentation for the ConfigMap used for Secure Forward Plugin

#### How should we test or review this PR?
Review the changes and compare with latest [OpenShift documentation](https://docs.openshift.com/container-platform/3.6/install_config/aggregate_logging.html#sending-logs-to-an-external-elasticsearch-instance)

#### Is there a relevant Trello card or Github issue open for this?
No

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this @etsauer @cpitman @JaredBurck
