### PR TITLE
Branding_console add ansible playbook links 

### DIFF
--- a/playbooks/operationalizing/branding_console.adoc
+++ b/playbooks/operationalizing/branding_console.adoc
@@ -279,6 +279,6 @@ Using below ansible playbook, it can be easy to change logo of OpenShift Login P
 *Playbook Lists*
 
 - https://github.com/redhat-cop/openshift-toolkit/tree/master/ansible-playbook-openshift-custom-login-page[ansible-playbook-openshift-custom-login-page]
-- https://github.com/redhat-cop/openshift-toolkit/tree/master/ansible-playbook-openshift-custom-webconsole-log[ansible-playbook-openshift-custom-webconsole-logo]
+- https://github.com/redhat-cop/openshift-toolkit/tree/master/ansible-playbook-openshift-custom-webconsole-logo[ansible-playbook-openshift-custom-webconsole-logo]
 
 

--- a/playbooks/operationalizing/branding_console.adoc
+++ b/playbooks/operationalizing/branding_console.adoc
@@ -274,9 +274,11 @@ Use the css class in a template::
 
 []
 == Ansible Playbooks
+Using below ansible playbook, it can be easy to change logo of OpenShift Login Page and Web Console. 
 
 *Playbook Lists*
-- [ansible-playbook-openshift-custom-login-page](https://github.com/redhat-cop/openshift-toolkit/tree/master/ansible-playbook-openshift-custom-login-page)
-- [ansible-playbook-openshift-custom-webconsole-logo](https://github.com/redhat-cop/openshift-toolkit/tree/master/ansible-playbook-openshift-custom-webconsole-log)
 
-With these ansible playbook, you can easily change logo of OpenShift Login Page and Web Console. Please follow the detail usage that is in git repository.
+- https://github.com/redhat-cop/openshift-toolkit/tree/master/ansible-playbook-openshift-custom-login-page[ansible-playbook-openshift-custom-login-page]
+- https://github.com/redhat-cop/openshift-toolkit/tree/master/ansible-playbook-openshift-custom-webconsole-log[ansible-playbook-openshift-custom-webconsole-logo]
+
+

--- a/playbooks/operationalizing/branding_console.adoc
+++ b/playbooks/operationalizing/branding_console.adoc
@@ -276,9 +276,9 @@ Use the css class in a template::
 == Ansible Playbooks
 Using below ansible playbook, it can be easy to change logo of OpenShift Login Page and Web Console. 
 
-*Playbook Lists*
+*Playbooks Links*
 
-- https://github.com/redhat-cop/openshift-toolkit/tree/master/ansible-playbook-openshift-custom-login-page[ansible-playbook-openshift-custom-login-page]
-- https://github.com/redhat-cop/openshift-toolkit/tree/master/ansible-playbook-openshift-custom-webconsole-logo[ansible-playbook-openshift-custom-webconsole-logo]
+- link:https://github.com/redhat-cop/openshift-toolkit/tree/master/ansible-playbook-openshift-custom-login-page[ansible-playbook-openshift-custom-login-page]
+- link:https://github.com/redhat-cop/openshift-toolkit/tree/master/ansible-playbook-openshift-custom-webconsole-logo[ansible-playbook-openshift-custom-webconsole-logo]
 
 

--- a/playbooks/operationalizing/branding_console.adoc
+++ b/playbooks/operationalizing/branding_console.adoc
@@ -273,17 +273,10 @@ Use the css class in a template::
 <1> This value must be same as the css style in extension.css
 
 []
-== Ansible Playbook
-This ansible playbook contains 4 roles : resize_image, configure_login_logo, configure_webconsole_logo, demo_template_icon_change.
-Those roles can be executed by 1 playbook or each role can be executed. This chapter will explain how to configure "Branding console" with ansible playbook.
+== Ansible Playbooks
 
+*Playbook Lists*
+- [ansible-playbook-openshift-custom-login-page](https://github.com/redhat-cop/openshift-toolkit/tree/master/ansible-playbook-openshift-custom-login-page)
+- [ansible-playbook-openshift-custom-webconsole-logo](https://github.com/redhat-cop/openshift-toolkit/tree/master/ansible-playbook-openshift-custom-webconsole-log)
 
-=== Ansible role
-- resize_image
-- configure_login_logo
-- configure_webconsole_logo
-- demo_template_icon_change
-
-=== Usage
-TBD
-
+With these ansible playbook, you can easily change logo of OpenShift Login Page and Web Console. Please follow the detail usage that is in git repository.


### PR DESCRIPTION
#### What is this PR About?
After ansible playbooks are merged to openshift-toolkit, the branding_console doc need to add those links.

#### How should we test or review this PR?
This is simple link update so I believe that clicking those links are enough to review

#### Is there a relevant Trello card or Github issue open for this?
Nope

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this
