### PR TITLE
Fix for travis-ci htmlproofer broken build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,8 @@ script:
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
+
+addons:
+  apt:
+    packages:
+    - libcurl4-openssl-dev # required to avoid SSL errors

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: ruby
 rvm:
 - 2.4.0
 
+cache:
+  directories:
+  - $TRAVIS_BUILD_DIR/tmp/.htmlproofer # https://github.com/gjtorikian/html-proofer/issues/381
+
 before_script:
  - chmod +x ./script/*
  - gem update --system 2.6.11
@@ -20,3 +24,5 @@ addons:
   apt:
     packages:
     - libcurl4-openssl-dev # required to avoid SSL errors
+
+sudo: false # route your build to the container-based infrastructure for a faster build

--- a/playbooks/installation/admin_overview.adoc
+++ b/playbooks/installation/admin_overview.adoc
@@ -56,7 +56,7 @@ OpenVSwitch is required on every host in order to support the OpenShift SDN comm
 
 IMPORTANT: Note that the `openvswitch` service is _disabled_ in `systemd`. This is because it is a dependency of the OpenShift Node service, and should not be started/stopped independently of that service.
 
-NOTE: For an overview of the OpenShift SDN, see the link:https://docs.openshift.com/enterprise/latest/architecture/additional_concepts/sdn.html[OpenShift SDN Architectural Overview]. For help troubleshooting SDN issues, see link:https://docs.openshift.com/enterprise/latest/admin_guide/sdn_troubleshooting.html[Troubleshooting the OpenShift SDN]
+NOTE: For an overview of the OpenShift SDN, see the link:https://docs.openshift.com/container-platform/latest/architecture/networking/sdn.html[OpenShift SDN Architectural Overview]. For help troubleshooting SDN issues, see link:https://docs.openshift.com/container-platform/latest/admin_guide/sdn_troubleshooting.html[Troubleshooting the OpenShift SDN]
 
 ----
 # systemctl status openvswitch

--- a/playbooks/operationalizing/cloudforms_networking.adoc
+++ b/playbooks/operationalizing/cloudforms_networking.adoc
@@ -99,7 +99,7 @@ To provide the greatest level of flexibility, SSL can be configured in several p
 
 * link:https://docs.openshift.com/container-platform/latest/install_config/cluster_metrics.html#metrics-using-secrets[Metrics Secrets Configuration]
 * link:https://docs.openshift.com/enterprise/latest/install_config/certificate_customization.html[Custom OpenShift certificates]
-* link:https://docs.openshift.com/container-platform/latest/architecture/core_concepts/routes.html#secured-routes[OpenShift router reencryption]
+* link:https://docs.openshift.com/container-platform/latest/architecture/networking/routes.html#secured-routes[OpenShift router reencryption]
 
 
 === OpenShift Configuration

--- a/script/cibuild.sh
+++ b/script/cibuild.sh
@@ -2,4 +2,4 @@
 set -e
 
 bundle exec jekyll build
-bundle exec htmlproofer ./_site --check-html
+bundle exec htmlproofer ./_site --only-4xx --check-html


### PR DESCRIPTION
#### What is this PR About?
updated the 404 broken links found by `html proofer`.  updated the travis config file to improve builds. And added `--only-4xx` flag to `html proofer` command in order to only throw an error when it hits an error message in the 400-499 range.

#### How should we test or review this PR?
verify the travis build is successful with no link errors.

#### Is there a relevant Trello card or Github issue open for this?
no

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this @etsauer @sabre1041 
