### PR TITLE
add --only-4xx flag for htmlproofer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ podTemplate(label: 'slave-ruby', cloud: 'openshift', serviceAccount: "jenkins", 
     stage('Run Automated Tests') {
       sh """
         export LANG=en_US.UTF-8
-        bundle exec htmlproofer ./_site --check-html
+        bundle exec htmlproofer ./_site --only-4xx --check-html
       """
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ podTemplate(label: 'slave-ruby', cloud: 'openshift', serviceAccount: "jenkins", 
     stage('Run Automated Tests') {
       sh """
         export LANG=en_US.UTF-8
-        bundle exec htmlproofer ./_site --only-4xx --check-html
+        bundle exec htmlproofer ./_site --check-html
       """
     }
 

--- a/script/cibuild.sh
+++ b/script/cibuild.sh
@@ -2,4 +2,4 @@
 set -e
 
 bundle exec jekyll build
-bundle exec htmlproofer ./_site --only-4xx --check-html
+bundle exec htmlproofer ./_site --check-html


### PR DESCRIPTION
#### What is this PR About?
Added the `--only-4xx` flag in the Jenkinsfile for htmlproofer to only throw an error when it hits an error message in the 400-499 range.

#### How should we test or review this PR?
Build the website using the Jenkinsfile and verify that the build is successful. 

#### Is there a relevant Trello card or Github issue open for this?
no. adds same fix as PR #220 

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this @etsauer 
