### PR TITLE
Change the link for ansible script

### DIFF
--- a/playbooks/operationalizing/branding_console.adoc
+++ b/playbooks/operationalizing/branding_console.adoc
@@ -278,7 +278,7 @@ Using below ansible playbook, it can be easy to change logo of OpenShift Login P
 
 *Playbooks Links*
 
-- link:https://github.com/redhat-cop/openshift-toolkit/tree/master/ansible-playbook-openshift-custom-login-page[ansible-playbook-openshift-custom-login-page]
-- link:https://github.com/redhat-cop/openshift-toolkit/tree/master/ansible-playbook-openshift-custom-webconsole-logo[ansible-playbook-openshift-custom-webconsole-logo]
+- link:https://github.com/redhat-cop/openshift-toolkit/tree/master/branding/ansible-playbook-openshift-custom-login-page[ansible-playbook-openshift-custom-login-page]
+- link:https://github.com/redhat-cop/openshift-toolkit/tree/master/branding/ansible-playbook-openshift-custom-webconsole-logo[ansible-playbook-openshift-custom-webconsole-logo]
 
 


### PR DESCRIPTION
#### What is this PR About?
The playbooks for branding console are moved to under branding folder (openshift-toolkit repo) so the link in the doc should be updated. Now it is broken.

#### How should we test or review this PR?
Click links

#### Is there a relevant Trello card or Github issue open for this?
#231

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this
