### PR TITLE
Making webhook secret a fixed value so re-applying template doesn't b…

### DIFF
--- a/build/dev/params
+++ b/build/dev/params
@@ -3,3 +3,4 @@ NAMESPACE=field-guides-dev
 SOURCE_REPOSITORY_URL=https://github.com/redhat-cop/openshift-playbooks.git
 SOURCE_REPOSITORY_REF=master
 IMAGE_STREAM_NAMESPACE=field-guides-dev
+GITHUB_WEBHOOK_SECRET=MOf6Hf05

--- a/build/template.yml
+++ b/build/template.yml
@@ -95,11 +95,6 @@ parameters:
   generate: expression
   name: GITHUB_WEBHOOK_SECRET
   required: true
-- description: Generic build trigger secret
-  from: '[a-zA-Z0-9]{8}'
-  generate: expression
-  name: GENERIC_WEBHOOK_SECRET
-  required: true
 - description: Namespace in which the ImageStreams for Red Hat Middleware images are
     installed. These ImageStreams are normally installed in the openshift namespace.
     You should only need to modify this if you've installed the ImageStreams in a


### PR DESCRIPTION
…reak the webhook

#### What is this PR About?
We weren't passing a value for the GITHUB_WEBHOOK_SECRET so it would be newly generated each time we applied the template, thus breaking the github webhook. This fixes that.

I also removed the GENERIC_WEBHOOK_SECRET parameter, as we don't use it anywhere in the template.

#### How should we test or review this PR?
Run the following and ensure the webhook still triggers:
```
oc process -f build/template.yml --param-file=build/dev/params | oc apply -f-
```

#### Is there a relevant Trello card or Github issue open for this?
n/a

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this
