### PR TITLE
Adding memory parameters to deployment configs

### DIFF
--- a/deploy/template.yml
+++ b/deploy/template.yml
@@ -54,7 +54,11 @@ objects:
           ports:
           - containerPort: 8080
             protocol: TCP
-          resources: {}
+          resources:
+            requests:
+              memory: ${MEMORY_REQUEST}
+            limits:
+              memory: ${MEMORY_LIMIT}
           terminationMessagePath: /dev/termination-log
         dnsPolicy: ClusterFirst
         restartPolicy: Always
@@ -144,3 +148,11 @@ parameters:
   required: true
 - description: Hostname for your application route
   name: APPLICATION_HOSTNAME
+- description: Requested Memory for Scheduling
+  name: MEMORY_REQUEST
+  required: true
+  value: 64Mi
+- description: Max memory consumption
+  name: MEMORY_LIMIT
+  required: true
+  value: 255Mi


### PR DESCRIPTION
#### What is this PR About?
Our production site runs under a tight quota, so I'm adding resource limits to make room for more pods.

#### How should we test or review this PR?
Deploy app, see that there are now resource limits in place.

```
oc process -f deploy/template.yml --param-file deploy/dev/params | oc apply -f -
```

#### Is there a relevant Trello card or Github issue open for this?
n/a

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this
