### PR TITLE
Add missing ending single quote on subscription-manager command

### DIFF
--- a/playbooks/installation/index.adoc
+++ b/playbooks/installation/index.adoc
@@ -830,7 +830,7 @@ cat /etc/yum.repos.d/ ...
 ==== Subscribing directly to Red Hat
 
 ----
-ansible -i c1-ocp.myorg.com/hosts OSEv3 -a 'subscription-manager register --username bob@acme.com --password='mypassword'
+ansible -i c1-ocp.myorg.com/hosts OSEv3 -a 'subscription-manager register --username bob@acme.com --password='mypassword''
 ansible -i c1-ocp.myorg.com/hosts OSEv3 -a 'subscription-manager attach --pool=8a85f98144844aff014488d058bf15be'
 ansible -i c1-ocp.myorg.com/hosts OSEv3 -a 'subscription-manager repos --disable="*" --enable="rhel-7-server-rpms" --enable="rhel-7-server-extras-rpms" --enable="rhel-7-server-ose-3.6-rpms" --enable="rhel-7-fast-datapath-rpms'
 ----
@@ -880,7 +880,7 @@ ansible -i c1-ocp.myorg.com/hosts nodes:!etcd  -m shell -a 'mount -a'
 === System Resource Reservations
 OpenShift has tunable parameters to futher enhance and protect the cluster/nodes.  These parameters should be added to your ansible hosts file.
 
-NOTE: OpenShift will use all the resources supplied to it from the node for the pods unless otherwise defined.  
+NOTE: OpenShift will use all the resources supplied to it from the node for the pods unless otherwise defined.
 
 ----
 openshift_node_kubelet_args="{'kube-reserved': ['cpu=250m,memory=500M'], 'system-reserved': ['cpu=250m,memory=500M'], 'eviction-hard': ['memory.available<100Mi'], 'minimum-container-ttl-duration': ['10s'], 'maximum-dead-containers-per-container': ['2'], 'maximum-dead-containers': ['50'], 'pods-per-core': ['10'], 'max-pods': ['250'], 'image-gc-high-threshold': ['80'], 'image-gc-low-threshold': ['60']}"

--- a/playbooks/installation/index.adoc
+++ b/playbooks/installation/index.adoc
@@ -830,7 +830,7 @@ cat /etc/yum.repos.d/ ...
 ==== Subscribing directly to Red Hat
 
 ----
-ansible -i c1-ocp.myorg.com/hosts OSEv3 -a 'subscription-manager register --username bob@acme.com --password='mypassword''
+ansible -i c1-ocp.myorg.com/hosts OSEv3 -a 'subscription-manager register --username bob@acme.com --password=mypassword'
 ansible -i c1-ocp.myorg.com/hosts OSEv3 -a 'subscription-manager attach --pool=8a85f98144844aff014488d058bf15be'
 ansible -i c1-ocp.myorg.com/hosts OSEv3 -a 'subscription-manager repos --disable="*" --enable="rhel-7-server-rpms" --enable="rhel-7-server-extras-rpms" --enable="rhel-7-server-ose-3.6-rpms" --enable="rhel-7-fast-datapath-rpms'
 ----


### PR DESCRIPTION
#### What is this PR About?
Fix a minor error with the subscription-manager command on line 833 as it is missing an ending quote.

#### How should we test or review this PR?
Verify the updated command.

#### Is there a relevant Trello card or Github issue open for this?
No, found the issue while working with a client.

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this @sabre1041 @etsauer 
