### PR TITLE
Replace rhel-7-server-ose-3.6-rpms with rhel-7-server-ose-3.7-rpms

### DIFF
--- a/playbooks/installation/index.adoc
+++ b/playbooks/installation/index.adoc
@@ -832,7 +832,7 @@ cat /etc/yum.repos.d/ ...
 ----
 ansible -i c1-ocp.myorg.com/hosts OSEv3 -a 'subscription-manager register --username bob@acme.com --password='mypassword'
 ansible -i c1-ocp.myorg.com/hosts OSEv3 -a 'subscription-manager attach --pool=8a85f98144844aff014488d058bf15be'
-ansible -i c1-ocp.myorg.com/hosts OSEv3 -a 'subscription-manager repos --disable="*" --enable="rhel-7-server-rpms" --enable="rhel-7-server-extras-rpms" --enable="rhel-7-server-ose-3.6-rpms" --enable="rhel-7-fast-datapath-rpms'
+ansible -i c1-ocp.myorg.com/hosts OSEv3 -a 'subscription-manager repos --disable="*" --enable="rhel-7-server-rpms" --enable="rhel-7-server-extras-rpms" --enable="rhel-7-server-ose-3.7-rpms" --enable="rhel-7-fast-datapath-rpms'
 ----
 
 NOTE: The `rhel-7-fast-datapath-rpms` channel is only required for OpenShift Container Platform version 3.5 and later. For versions 3.4 and earlier, this channel should be omitted.


### PR DESCRIPTION
Still listed the 3.6 rpms while rest of document references 3.7

#### What is this PR About?
Typo in repo command

#### How should we test or review this PR?
Should be obvious :)

#### Is there a relevant Trello card or Github issue open for this?
no

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this
