### PR TITLE
Updated versions for plugins that the Openshift Sync Plugin depends on for External Jenkins Integration

### DIFF
--- a/playbooks/continuous_delivery/external-jenkins-integration.adoc
+++ b/playbooks/continuous_delivery/external-jenkins-integration.adoc
@@ -36,26 +36,29 @@ To support connectivity between OpenShift and Jenkins, the following network lev
 
 The majority of the capabilities provided by the integration between OpenShift and Jenkins are made possible through a collection of Jenkins plugins.
 
-* link:https://wiki.jenkins-ci.org/display/JENKINS/OpenShift+Pipeline+Plugin[OpenShift Pipeline] - The ability to trigger actions in OpenShift, such as starting a build or deployment. 
-* link:https://wiki.jenkins-ci.org/display/JENKINS/OpenShift+Sync+Plugin[OpenShift Sync] - Synchronizing the state of Jenkins jobs and OpenShift objects (BuildConfigs) in order to facilitate integrated pipelines. 
-* link:https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin[Kubernetes Plugin] - The ability to trigger actions in OpenShift, such as starting a build or deployment. 
+* link:https://wiki.jenkins-ci.org/display/JENKINS/OpenShift+Pipeline+Plugin[OpenShift Pipeline] - The ability to trigger actions in OpenShift, such as starting a build or deployment.
+* link:https://wiki.jenkins-ci.org/display/JENKINS/OpenShift+Sync+Plugin[OpenShift Sync] - Synchronizing the state of Jenkins jobs and OpenShift objects (BuildConfigs) in order to facilitate integrated pipelines.
+
+IMPORTANT: As of version `0.9.2`, the Openshift Sync plugin *requires* version `1.6.1` of both the link:https://updates.jenkins-ci.org/download/plugins/blueocean-commons/[Blueocean-commons] and link:https://updates.jenkins-ci.org/download/plugins/blueocean-rest/[Blueocean-rest] plugins. Users may have to downgrade the versions of these plugins that come preinstalled with Jenkins. How to do so is beyond the scope of this article.
+
+* link:https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin[Kubernetes Plugin] - The ability to trigger actions in OpenShift, such as starting a build or deployment.
 * link:https://wiki.jenkins-ci.org/display/JENKINS/OpenShift+Client+Plugin[OpenShift Client Plugin] - Jenkins Pipeline DSL for interacting with OpenShift.
 
-NOTE: Starting in OpenShift version 3.4, the included Jenkins image provided by the platform began to leverage the link:https://wiki.jenkins-ci.org/display/JENKINS/OpenShift+Login+Plugin[OpenShift Login Plugin]  which enabled integrated authentication between OpenShift and Jenkins. The process for configuring this plugin in an externally facing Jenkins instance will not be covered in this article 
+NOTE: Starting in OpenShift version 3.4, the included Jenkins image provided by the platform began to leverage the link:https://wiki.jenkins-ci.org/display/JENKINS/OpenShift+Login+Plugin[OpenShift Login Plugin]  which enabled integrated authentication between OpenShift and Jenkins. The process for configuring this plugin in an externally facing Jenkins instance will not be covered in this article
 
 Each of these plugins must be installed within an existing Jenkins instance. As a Jenkins user with administrator access, login to Jenkins and navigate to *Manage Jenkins* -> *Plugin Manager*. Click on the *Available* tab and search for the plugins listed above. Check the box next to each of the plugins and when complete, select *Download now and install after restart*.
 
 ==  Credentials
 
-With the required Jenkins plugins installed, to perform many of the aforementioned actions provided by the plugins, Jenkins must be able to communicate and authenticate against OpenShift. To do so, a service account within OpenShift should be created. 
+With the required Jenkins plugins installed, to perform many of the aforementioned actions provided by the plugins, Jenkins must be able to communicate and authenticate against OpenShift. To do so, a service account within OpenShift should be created.
 
-NOTE:  A service account in OpenShift makes use of a non-expiring OAuth token which is ideal for situations such as this. 
+NOTE:  A service account in OpenShift makes use of a non-expiring OAuth token which is ideal for situations such as this.
 
-Once the service account has been created, the OAuth token will be stored as Credentials within Jenkins 
+Once the service account has been created, the OAuth token will be stored as Credentials within Jenkins
 
 === Service Account Creation within OpenShift
 
-Service accounts within OpenShift are scoped to a single project. Even though Jenkins will not be running within OpenShift, it is recommended that a separate project be created to support a separation of duties within the platform and to provide a location to execute dynamic slaves as described in subsequent sections. The project name _ci_ will be used in the examples below, but you are free to select any name you wish. 
+Service accounts within OpenShift are scoped to a single project. Even though Jenkins will not be running within OpenShift, it is recommended that a separate project be created to support a separation of duties within the platform and to provide a location to execute dynamic slaves as described in subsequent sections. The project name _ci_ will be used in the examples below, but you are free to select any name you wish.
 
 Using the OpenShift Command Line Tool (CLI), login to OpenShift as and create a new project called _ci_
 
@@ -142,9 +145,9 @@ Hit *OK* to create the new credential
 
 == OpenShift Sync Plugin
 
-The Jenkins OpenShift Sync Plugin is responsible for synchronizing the state of BuildConfig API objects in OpenShift and jobs within Jenkins. Whenever a new BuildConfig with a _JenkinsPipeline_ type is created in OpenShift, the contents result in a new job in Jenkins. 
+The Jenkins OpenShift Sync Plugin is responsible for synchronizing the state of BuildConfig API objects in OpenShift and jobs within Jenkins. Whenever a new BuildConfig with a _JenkinsPipeline_ type is created in OpenShift, the contents result in a new job in Jenkins.
 
-From the overview page, configure the OpenShift sync plugin within the system configuration page by selecting *Manage Jenkins* -> *Configure System*. 
+From the overview page, configure the OpenShift sync plugin within the system configuration page by selecting *Manage Jenkins* -> *Configure System*.
 
 Locate the _OpenShift Jenkins Sync_ section. The following table describes the fields presented:
 
@@ -173,13 +176,13 @@ Hit *Save* to apply the changes.
 
 == Dynamic Slaves
 
-To offload the workload from Jenkins masters, the concepts of slaves was introduced as a way to perform job execution on a set of link:https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds[distributed instances]. Since OpenShift provides a set of elastic computing resources, it is ideal for running Jenkins slaves. The Jenkins Kubernetes plugin facilitates the communication between Jenkins and OpenShift along with managing the slave lifecycle. 
+To offload the workload from Jenkins masters, the concepts of slaves was introduced as a way to perform job execution on a set of link:https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds[distributed instances]. Since OpenShift provides a set of elastic computing resources, it is ideal for running Jenkins slaves. The Jenkins Kubernetes plugin facilitates the communication between Jenkins and OpenShift along with managing the slave lifecycle.
 
 === JNLP Port
 
-Jenkins slaves running in OpenShift communicate with the Jenkins master using a separate TCP connection. The TCP port to make use of is specified in the _Configure Global Security_ within Jenkins management page. From the Jenkins overview page, select *Manage Jenkins* -> *Configure Global Security*. 
+Jenkins slaves running in OpenShift communicate with the Jenkins master using a separate TCP connection. The TCP port to make use of is specified in the _Configure Global Security_ within Jenkins management page. From the Jenkins overview page, select *Manage Jenkins* -> *Configure Global Security*.
 
-Underneath the _Enable Security_ checkbox, locate  _TCP port for JNLP Agents_ and select the *Fixed* radio button. Enter *50000* as the TCP port. 
+Underneath the _Enable Security_ checkbox, locate  _TCP port for JNLP Agents_ and select the *Fixed* radio button. Enter *50000* as the TCP port.
 
 NOTE: Any TCP port could be specified, however port 50000 is the default within all Red Hat provided Jenkins slaves as well as many community based slaves
 
@@ -194,7 +197,7 @@ The configuration for the Kubernetes plugin is specified in the _Cloud_ section.
 
 Defining a new kubernetes cloud requires several values to be configured and are detailed in the table below
 
-NOTE: The items defined in the tables within this section are the minimum number of required values in order for successful execution. Additional configurations may be defined as necessary 
+NOTE: The items defined in the tables within this section are the minimum number of required values in order for successful execution. Additional configurations may be defined as necessary
 
 .Kubernetes Cloud Configuration
 [options="header"]
@@ -209,13 +212,13 @@ NOTE: The items defined in the tables within this section are the minimum number
 
 |Disable https certificate check|If a certificate was not added above, use this checkbox to disable certificate validation
 
-|Kubernetes namespace|The namespace in which slave pods will be created. This value can be overridden by using an inline node configuration within the Jenkins pipeline execution. 
+|Kubernetes namespace|The namespace in which slave pods will be created. This value can be overridden by using an inline node configuration within the Jenkins pipeline execution.
 
 |Credentials|Select the name of the credential previously configured from the drop down.Clicking *Test Credential* will verify proper configuration of the OpenShift URL, certificate and credential.
 
-|Jenkins URL|The URL of the Jenkins web console 
+|Jenkins URL|The URL of the Jenkins web console
 
-|Jenkins tunnel|The address for JNLP slaves to communicate to the Jenkins master as configured in the <<JNLP Port>> section.  
+|Jenkins tunnel|The address for JNLP slaves to communicate to the Jenkins master as configured in the <<JNLP Port>> section. If entering just the port number, prefix it with a `:` i.e. (`:50000`).
 
 |=========================================================
 
@@ -232,7 +235,7 @@ As of OpenShift version 3.5, the following slave images are available:
 
 |base| *registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7*
 
-|maven| *registry.access.redhat.com/openshift3/jenkins-slave-maven-rhel7* 
+|maven| *registry.access.redhat.com/openshift3/jenkins-slave-maven-rhel7*
 
 |nodejs| *registry.access.redhat.com/openshift3/jenkins-slave-nodejs-rhel7*
 
@@ -250,7 +253,7 @@ Using the table below, create a new pod template for each Jenkins slaves that yo
 
 |Name|Friendly name of the pod template
 
-|Label|Label that is applied by users to signify their intention to have their build execute this pod template. It is recommended that _maven_ or _nodejs_ be entered depending on the template  
+|Label|Label that is applied by users to signify their intention to have their build execute this pod template. It is recommended that _maven_ or _nodejs_ be entered depending on the template
 
 |=========================================================
 
@@ -264,7 +267,7 @@ Use the values in the following table to fill out the template
 
 |Name| *jnlp*
 
-|Image|_Image to use for the container_ (such as *registry.access.redhat.com/openshift3/jenkins-slave-maven-rhel7*) 
+|Image|_Image to use for the container_ (such as *registry.access.redhat.com/openshift3/jenkins-slave-maven-rhel7*)
 
 |Working Directory| */tmp*
 
@@ -305,7 +308,7 @@ spec:
         node("maven") {
           stage("echo") {
             println("Hello World")
-          }            
+          }
         }
 ----
 
@@ -325,16 +328,12 @@ image::images/external-jenkins-synced-job.png[title=Synchronized Jenkins Job fro
 
 Using either the sample Jenkins job created in the previous section or another job, perform the following steps to validate slaves are dynamically being utilized.
 
-From the Jenkins overview page, select the job that was automatically created. 
+From the Jenkins overview page, select the job that was automatically created.
 
 Select *Build Now* link on the left side to initiate the build process. Once complete, a visualization of the pipeline and its status displayed similar to the following:
 
 image::images/external-jenkins-build.png[title=Successful Jenkins Build]
 
-The pipeline can also be viewed within the OpenShift web console by navigating to *Builds* -> *Pipelines* from within the target project. 
+The pipeline can also be viewed within the OpenShift web console by navigating to *Builds* -> *Pipelines* from within the target project.
 
 image::images/external-jenkins-ocp-pipeline.png[title=OpenShift Pipelines]
-
-
-
-


### PR DESCRIPTION
#### What is this PR About?
The Openshift Sync plugin bundled with the latest Jenkins needs specific versions of particular BlueOcean plugins in order to work. I've updated the External Jenkins documentation to reflect this fact. 
I've also explicitly spelled out how the JLNP ports should be provided.

#### How should we test or review this PR?
- Download the latest Jenkins.
- Attempt to setup and test a sample external Jenkins pipeline *without* downgrading the BlueOcean plugins.
- The pipeline will throw an exception and fail to execute.
- Downgrade the plugins as per the PR and execute the pipeline again, it will succeed.

#### Is there a relevant Trello card or Github issue open for this?
No.

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this
@etsauer
