### PR TITLE
Add the <store> tags around the secure forward config.

### DIFF
--- a/playbooks/operationalizing/secure-forward-splunk-container.adoc
+++ b/playbooks/operationalizing/secure-forward-splunk-container.adoc
@@ -161,6 +161,7 @@ Edit the following YAML:
 ----
 data:
   secure-forward.conf: |
+    <store>
     @type secure_forward
 
     self_hostname ${HOSTNAME}
@@ -175,6 +176,7 @@ data:
        host fluentd-forwarder.logging.svc.cluster.local
        port 24284
     </server>
+    </store>
 ----
 <1> A shared value between the sender and the receiver.  This must match the value specified above.
 


### PR DESCRIPTION
#### What is this PR About?
Adds the <store> tags around the secure forward configuration, so that other stores don't get clobbered(e.g., OpenShift's own Elasticsearch).

#### How should we test or review this PR?
On an existing cluster with EFK already deployed, then deploy with this configmap. Logs should ship to both stores.

Also see #193 

#### Is there a relevant Trello card or Github issue open for this?
No.

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this
