### PR TITLE
Updated to be able to use latest OpenShift-Applier inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _site
 .bundle
 /.settings/
 /.project
+/galaxy/

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '2.4.3'
 gem 'jekyll', '<3.0.0'
 gem 'asciidoctor', '1.5.2'
 gem 'html-proofer'
-gem 'ffi', '1.9.23'
+gem 'ffi', '1.9.24'
 
 group :jekyll_plugins do
   gem "jekyll-asciidoc", '1.0.0'

--- a/inventory-dev/group_vars/all.yml
+++ b/inventory-dev/group_vars/all.yml
@@ -5,7 +5,7 @@ openshift_cluster_content:
   content:
   - name: "Projects"
     file: "{{ inventory_dir }}/../projects/projects-dev.yml"
-    file_action: create
+    action: create
 - object: policy
   content:
   - name: "Apply policy directory"

--- a/inventory-prod/group_vars/all.yml
+++ b/inventory-prod/group_vars/all.yml
@@ -5,7 +5,7 @@ openshift_cluster_content:
   content:
   - name: "Projects"
     file: "{{ inventory_dir }}/../projects/projects-prod.yml"
-    file_action: create
+    action: create
 - object: policy
   content:
   - name: "Apply policy directory"

--- a/openshift-playbooks-requirements.yml
+++ b/openshift-playbooks-requirements.yml
@@ -1,0 +1,7 @@
+# This is the Ansible Galaxy requirements file to pull in the correct roles to
+# support the operation of openshift-playbooks provisioning/deployment website.
+# This also supports any role dependency while using the repository in Ansible Tower
+
+# From 'openshift-applier'
+- src: https://github.com/redhat-cop/openshift-applier
+  version: v2.0.3

--- a/pipeline.md
+++ b/pipeline.md
@@ -15,7 +15,7 @@ First, log in to the Dev cluster and run the dev inventory to set up the dev env
 ```
 oc login <dev cluster>
 cd ./openshift-playbooks
-ansible-playbook -i inventory-dev/ ../casl-ansible/playbooks/openshift-cluster-seed.yml --connection=local
+ansible-playbook -i inventory-dev/ path/to/openshift-applier/playbooks/openshift-cluster-seed.yml --connection=local
 ```
 
 ## 2 Production Setup
@@ -23,7 +23,7 @@ ansible-playbook -i inventory-dev/ ../casl-ansible/playbooks/openshift-cluster-s
 Log into the Production cluster and run the production setup inventory.
 ```
 oc login <prod cluster>
-ansible-playbook -i inventory-prod/ ../casl-ansible/playbooks/openshift-cluster-seed.yml --connection=local
+ansible-playbook -i inventory-prod/ path/to/openshift-applier/playbooks/openshift-cluster-seed.yml --connection=local
 ```
 
 ## 3 Create the Promoter Secret

--- a/pipeline.md
+++ b/pipeline.md
@@ -9,6 +9,8 @@ This pipeline has a few dependencies outsite of this repo:
 
 The following are instructions to get the application deployed.
 
+**Note** *If using macOS High Sierra you may need to `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` as an environment variable if using Ansible > 2.3+, as described in this [Ansible issue](https://github.com/ansible/ansible/issues/32499).*
+
 ## 1 Development/Testing Setup
 
 First, log in to the Dev cluster and run the dev inventory to set up the dev environment.

--- a/pipeline.md
+++ b/pipeline.md
@@ -6,29 +6,46 @@ This pipeline has a few dependencies outsite of this repo:
 
 - A Ruby Jenkins Slave Image: https://github.com/etsauer/containers-quickstarts/tree/jenkins-slave-ruby/jenkins-slaves/jenkins-slave-ruby
 - A Skopeo Jenkins Slave Image: https://github.com/redhat-cop/containers-quickstarts/tree/master/jenkins-slaves/jenkins-slave-image-mgmt
+- [OpenShift-Applier](https://github.com/redhat-cop/openshift-applier) - used to deploy the CI/CD infrastructure and pipeline jobs for deploying the website.
 
 The following are instructions to get the application deployed.
 
-**Note** *If using macOS High Sierra you may need to `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` as an environment variable if using Ansible > 2.3+, as described in this [Ansible issue](https://github.com/ansible/ansible/issues/32499).*
+## 1 Initial Environment Setup
+First, clone *this* repository into a directory such as `~/src/`
+```
+cd ~/src/
+git clone https://github.com/redhat-cop/openshift-playbooks.git
+```
 
-## 1 Development/Testing Setup
+Run `ansible-galaxy` to pull in the necessary requirements for the provisioning of openshift-playbooks:
 
-First, log in to the Dev cluster and run the dev inventory to set up the dev environment.
+- **NOTE:**  *The target directory ( `galaxy` ) is important as the playbooks know to source roles and playbooks from that location.*
+
+```
+cd ~/src/openshift-playbooks
+ansible-galaxy install -r openshift-playbooks-requirements.yml -p galaxy
+```
+
+- **Note:**  *If using macOS High Sierra you may need to `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` as an environment variable if using Ansible > 2.3+, as described in this [Ansible issue](https://github.com/ansible/ansible/issues/32499).*
+
+## 2 Development/Testing Setup
+
+Next, log in to the Dev cluster and run the dev inventory to set up the dev environment.
 ```
 oc login <dev cluster>
 cd ./openshift-playbooks
-ansible-playbook -i inventory-dev/ path/to/openshift-applier/playbooks/openshift-cluster-seed.yml --connection=local
+ansible-playbook -i inventory-dev/ ~/src/openshift-playbooks/galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml --connection=local
 ```
 
-## 2 Production Setup
+## 3 Production Setup
 
 Log into the Production cluster and run the production setup inventory.
 ```
 oc login <prod cluster>
-ansible-playbook -i inventory-prod/ path/to/openshift-applier/playbooks/openshift-cluster-seed.yml --connection=local
+ansible-playbook -i inventory-prod/ ~/src/openshift-playbooks/galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml --connection=local
 ```
 
-## 3 Create the Promoter Secret
+## 4 Create the Promoter Secret
 
 As part of the ansible run above, a service account called _promoter_ gets created with the "edit" role, in order to facilitate the promotion of the site from dev to production. Grab the token value for the service account created above and save for later
 ```


### PR DESCRIPTION
#### What is this PR About?
OpenShift-Applier inventory `file_action` had been refactored to use `action` and this inventory had not been updated to use the latest syntax that this PR fixes.  This also adds a note about an issue with macOS High Sierra and Ansible 2.4+.  And `ffi` was updated from 1.9.23 to 1.9.24 to resolve known security vulnerabilities.

#### How should we test or review this PR?
build and deploy site following the [pipeline deployment guide](https://github.com/redhat-cop/openshift-playbooks/blob/master/pipeline.md)

#### Is there a relevant Trello card or Github issue open for this?
n/a

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this  @etsauer 
