### PR TITLE
[POC] Buildah Container Support

### DIFF
--- a/container-images/local-builder/buildah.sh
+++ b/container-images/local-builder/buildah.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+
+FROM="ruby:2.4.0-alpine"
+
+CONTAINER=$(buildah from --pull-always ${FROM})
+USER_UID="1001"
+CHOME="/home/jekyll"
+
+# install packages
+buildah run $CONTAINER apk add --no-cache --update make gcc libc-dev python libcurl
+
+# copy files to container
+buildah copy $CONTAINER $(pwd)/root/ /
+
+# configure environment variables
+buildah config --env "HOME=${CHOME}" --env "USER_UID=${USER_UID}" $CONTAINER
+
+# handle setup tasks in user script
+buildah run $CONTAINER /bin/sh /usr/local/bin/user_setup
+
+# clean up
+buildah run $CONTAINER rm -rf /var/cache/apk
+
+# finalize configuration
+buildah config --entrypoint '["/usr/local/bin/entrypoint"]' --cmd "/usr/local/bin/run" --workingdir "${CHOME}" --user "${USER_UID}" --port 4000 $CONTAINER
+
+# commit
+buildah commit $CONTAINER redhatcop/jekyll-local-builder:buildah
+
+# stop container when done
+buildah rm $CONTAINER


### PR DESCRIPTION
#### What is this PR About?
This is a POC for a buildah/podman capability for contributors to build/test the site.

#### How should we test or review this PR?
* Install buildah and podman
* Use the included `container-images/local-builder/buildah.sh` script to build the image
* Use the podman command to execute the container from the root of this repository (just like the docker command)
```bash
[]$ podman run -ti -u $(id -u) -v $(pwd):/home/jekyll/src:Z localhost/redhatcop/jekyll-local-builder:buildah
```

#### Is there a relevant Trello card or Github issue open for this?
No.

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this