### PR TITLE
Remove references to Openshift Enterprise

### DIFF
--- a/development_guide.adoc
+++ b/development_guide.adoc
@@ -9,7 +9,7 @@ toc::[]
 
 == What is a Delivery Playbook?
 
-A _delivery playbook_ is a guide for implementing DevOps technical practices and container automation approaches using Red Hat commercial open source products, including OpenShift Enterprise 3. Playbooks are intended to reflect real-world experience delivering solutions through these processes and technologies.
+A _delivery playbook_ is a guide for implementing DevOps technical practices and container automation approaches using Red Hat commercial open source products, including OpenShift Container Platform 3. Playbooks are intended to reflect real-world experience delivering solutions through these processes and technologies.
 
 == Delivery Playbook Components
 

--- a/index.adoc
+++ b/index.adoc
@@ -2,7 +2,7 @@
 ---
 = Red Hat Consulting DevOps and OpenShift Playbooks
 
-Red Hat Consulting DevOps and OpenShift Playbooks are guides for implementing DevOps technical practices and container automation approaches using Red Hat commercial open source products, including OpenShift Enterprise 3. They are intended to reflect real-world experience delivering solutions through these processes and technologies.
+Red Hat Consulting DevOps and OpenShift Playbooks are guides for implementing DevOps technical practices and container automation approaches using Red Hat commercial open source products, including OpenShift Container Platform 3. They are intended to reflect real-world experience delivering solutions through these processes and technologies.
 
 == Playbook Directory
 
@@ -13,9 +13,9 @@ Current in-development playbooks include the following:
 ////
 * link:playbooks/fundamentals[OpenShift & Container Fundamentals]
 * link:playbooks/installation[Installing a Highly-Available OpenShift Cluster]
-* link:playbooks/app_dev[OpenShift Enterprise 3 Application Development]
+* link:playbooks/app_dev[OpenShift Container Platform 3 Application Development]
 * link:playbooks/continuous_delivery[Container-Driven Continuous Delivery]
-* link:playbooks/operationalizing[Operationalizing OpenShift Enterprise 3]
+* link:playbooks/operationalizing[Operationalizing OpenShift Container Platform 3]
 * link:playbooks/troubleshooting[Troubleshooting]
 * link:playbooks/fundamentals/openshift_roles_responsibilities{outfilesuffix}[Guide: OpenShift & the Organization]
 ////

--- a/playbooks/app_dev/index.adoc
+++ b/playbooks/app_dev/index.adoc
@@ -1,8 +1,8 @@
 ---
 ---
-= OpenShift Enterprise 3 Application Development
+= OpenShift Container Platform 3 Application Development
 
-The OpenShift Enterprise 3 Application Development playbook provides guidance on application development concerns in OSE 3, including containerized build and deployment processes.
+The OpenShift Container Platform 3 Application Development playbook provides guidance on application development concerns in OSE 3, including containerized build and deployment processes.
 
 Completed sections:
 

--- a/playbooks/continuous_delivery/image_promotion.adoc
+++ b/playbooks/continuous_delivery/image_promotion.adoc
@@ -1,6 +1,6 @@
 ---
 ---
-= OpenShift Enterprise 3 Image Promotion Strategies
+= OpenShift Container Platform 3 Image Promotion Strategies
 Andrew Block <ablock@redhat.com>
 v1.0, 2015-10-05
 :scripts_repo: https://github.com/rhtconsulting/rhc-ose
@@ -134,4 +134,3 @@ skopeo copy \
 ----
 
 Skopeo also has the advantage of being able to work with many image and repository types, including OCI containers and connecting directly to a docker daemon.
-

--- a/playbooks/index.adoc
+++ b/playbooks/index.adoc
@@ -6,7 +6,7 @@ Current in-development playbooks include the following:
 
 * link:/playbooks/fundamentals[OpenShift & Container Fundamentals]
 * link:/playbooks/continuous_delivery[Container-Driven Continuous Delivery]
-* link:/playbooks/installation[OpenShift Enterprise 3 SmartStart (Production-Ready Installation and Configuration)]
-* link:/playbooks/app_dev[OpenShift Enterprise 3 Application Development]
-* link:/playbooks/operationalizing[Operationalizing OpenShift Enterprise 3]
+* link:/playbooks/installation[OpenShift Container Platform 3 SmartStart (Production-Ready Installation and Configuration)]
+* link:/playbooks/app_dev[OpenShift Container Platform 3 Application Development]
+* link:/playbooks/operationalizing[Operationalizing OpenShift Container Platform 3]
 * link:/playbooks/troubleshooting[Troubleshooting]

--- a/playbooks/operationalizing/index.adoc
+++ b/playbooks/operationalizing/index.adoc
@@ -1,14 +1,14 @@
 ---
 ---
-= Operationalizing OpenShift Enterprise 3
+= Operationalizing OpenShift Container Platform 3
 
-The Operationalizing OpenShift Enterprise 3 playbook provides guidance on environment architecture concerns such as component placement and network topology and discusses related system integration issues.
+The Operationalizing OpenShift Container Platform 3 playbook provides guidance on environment architecture concerns such as component placement and network topology and discusses related system integration issues.
 
 * link:../installation/admin_overview{outfilesuffix}[Overview of OpenShift for Administrators]
 * link:../installation/ldap_integration{outfilesuffix}[Integrating OpenShift with LDAP/Active Directory for Authentication]
 * link:./architecture{outfilesuffix}[Architecture]
 * link:./integration{outfilesuffix}[API Integration Guide]
-* link:./cloudforms{outfilesuffix}[CloudForms Integration with OpenShift Enterprise v3]
+* link:./cloudforms{outfilesuffix}[CloudForms Integration with OpenShift Container Platform 3]
 ** link:./cloudforms_networking{outfilesuffix}[Network Integration for OpenShift v3 and Red Hat CloudForms]
 * link:./custom_role_creation{outfilesuffix}[Custom Role Creation]
 * link:./expose_docker_registry{outfilesuffix}[Exposing & Securing the OpenShift Docker Registry]


### PR DESCRIPTION
#### What is this PR About?
Removing the old name OpenShift enterprise and replace it with the new name Openshift Container platform

#### How should we test or review this PR?
N/A

#### Is there a relevant Trello card or Github issue open for this?
Couldn't find any.

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this
